### PR TITLE
error handling: fixed event name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
-pipelines
-=========
+Mixdown Pipelines
+=================
+
+## pipelines.static - stream your static files. Usage:
+
+##### Add pipeline plugin to your mixdown.json
+
+```javascript
+"app": {
+  "plugins": {
+    "pipelines": {
+      "module": "mixdown-pipelines"
+    }
+  }
+}
+```
+##### Add your static route handler:
+
+```javascript
+module.exports = function(httpContext) {
+  var app = httpContext.app;
+  var pl = app.plugins.pipelines.static();
+
+  pl.name += ': ' + httpContext.url.path;
+
+  pl.execute({
+    path: httpContext.url.pathname.replace(/\/img/, ''),
+    res: httpContext.response,
+    locations: ['./' + app.id + '/img']
+  });
+};
+```

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ PipelineFactory.prototype.attach = function (options) {
         // set timeout for all pipelines.
         pl.timeout = options.timeout;
 
-        pl.on('error', function(err, results) {
+        pl.on('end', function(err, results) {
             var res = results[0] ? results[0].res : null;
 
             if (err) {


### PR DESCRIPTION
Currently pipeline listens to 'error' event which never happens:

``` javascript
var newPipeline = function(name, res) {
  var pl = Pipeline.create(app.config.id + '-' + name);

  // set timeout for all pipelines.
  pl.timeout = options.timeout;

  pl.on('error', function(err, results) {
    var res = results[0] ? results[0].res : null;
    ...
```

As a result, you will never see error page when static resource not found (timeout instead).
So this pull request changes event name from 'error' to 'end' (and it works then and i see error page + log entry when file not found).

``` javascript
  pl.on('end', function(err, results) {
    var res = results[0] ? results[0].res : null;
    ...
```

Plus, i've updated README with some very basic plugin usage instructions.
